### PR TITLE
Fixed smoothScroll working on external url with hash

### DIFF
--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -339,6 +339,7 @@ jQuery( document ).ready( function( $ ){
 
     // Other scroll to elements
     jQuery( 'body' ).on('click', '.swiper-slide a[href*="#"]:not([href="#"]), .parallax-content a[href*="#"]:not([href="#"]), .back-top-top', function(event){
+        if (!/^#/.test(this.href)) return;
         event.preventDefault();
 		if ( $( '.nav-menu' ).hasClass( 'nav-menu-mobile' ) ) {
 			$( '#nav-toggle' ).trigger( 'click' );

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -339,7 +339,7 @@ jQuery( document ).ready( function( $ ){
 
     // Other scroll to elements
     jQuery( 'body' ).on('click', '.swiper-slide a[href*="#"]:not([href="#"]), .parallax-content a[href*="#"]:not([href="#"]), .back-top-top', function(event){
-        if (!/^#/.test(this.href)) return;
+        if (this.host != window.location.host) return;
         event.preventDefault();
 		if ( $( '.nav-menu' ).hasClass( 'nav-menu-mobile' ) ) {
 			$( '#nav-toggle' ).trigger( 'click' );


### PR DESCRIPTION
The original code is run `smoothScroll` on every URL with `#`, though it's another different domain name. It still tries to call `smoothScroll`.

So I added `if (!/^#/.test(this.href)) return;` to make it work only for same page hash URL.